### PR TITLE
Change type of tv_usec to Unsigned32

### DIFF
--- a/gettimeofday/src/main/java/gettimeofday/Gettimeofday.java
+++ b/gettimeofday/src/main/java/gettimeofday/Gettimeofday.java
@@ -11,7 +11,7 @@ import jnr.ffi.annotations.Transient;
 public class Gettimeofday {
     public static final class Timeval extends Struct {
         public final time_t tv_sec = new time_t();
-        public final SignedLong tv_usec = new SignedLong();
+        public final Unsigned32 tv_usec = new Unsigned32();
 
         public Timeval(Runtime runtime) {
             super(runtime);


### PR DESCRIPTION
The field tv_usec is a 4-bytes integer. Using SignedLong works under Linux systems, but yields unpredictable results under Mac OS X. Using Unsigned32 fixes the problem and works under both systems.
