### PR TITLE
Bump up to jnr-ffi 2.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-ffi</artifactId>
-        <version>1.0.5</version>
+        <version>2.0.9</version>
     </dependency>
   </dependencies>
-  
+
 </project>


### PR DESCRIPTION
@headius it seems like the changes here are https://github.com/jnr/jnr-ffi-examples/pull/2 are no longer necessary. I've updated the pom file and everything seems to be working.

Thanks you and Enebo for maintaining this project.